### PR TITLE
add breakpoint for tablet homepage

### DIFF
--- a/components/GameStartForm/styles.module.css
+++ b/components/GameStartForm/styles.module.css
@@ -76,3 +76,9 @@
   margin: 20px 0;
   text-shadow: 1px 1px 2px black;
 }
+
+@media (max-width: 768px) {
+  .difficultyHeading {
+    font-size: 55px;
+  }
+}

--- a/components/PageContainer/styles.module.css
+++ b/components/PageContainer/styles.module.css
@@ -2,6 +2,5 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  min-width: 1037px;
   background-size: 100vw 100vh;
 }

--- a/pages/styles.module.css
+++ b/pages/styles.module.css
@@ -3,14 +3,20 @@
   border-image: linear-gradient(#ffe341, #ffffff, #ffe341) 30;
   border-width: 16px;
   border-style: solid;
-  min-width: 1037px;
 }
 
 .homepageTitle {
   font-family: "gyparody";
   font-size: 120px;
+  text-align: center;
   color: var(--yellow);
   text-shadow: 0 1px 0 #3c391e, 0 2px 0 #3c391e, 0 3px 0 #3c391e,
     0 4px 0 #3c391e, 0 5px 0 #3c391e, 0 20px 30px rgba(0, 0, 0, 0.5);
   margin-bottom: 0.5em;
+}
+
+@media (max-width: 768px) {
+  .homepageTitle {
+    font-size: 100px;
+  }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,4 +21,5 @@ body {
   height: 100vh;
   color: var(--white);
   background: url("../public/subtle-prism.svg");
+  background-size: cover;
 }


### PR DESCRIPTION
This PR adds breakpoints on homepage for tablet view (width: 768px)

<img width="576" alt="Screen Shot 2023-03-22 at 12 07 16 PM" src="https://user-images.githubusercontent.com/100656411/227011050-b9f8d6e2-e479-4f5b-b37d-c48e4b211bcb.png">
