### PR TITLE
Tablet results

### DIFF
--- a/components/Gameboard/index.js
+++ b/components/Gameboard/index.js
@@ -32,7 +32,7 @@ const Gameboard = () => {
           <PlayerScores />
         </div>
       </DropAnimation>
-      <PushAnimation>
+      <PushAnimation isGameboard={true}>
         <div className={styles.gameboardBorder}>
           <CatergoriesRow categories={categories} />
           <ValueBoard />

--- a/components/PushAnimation/index.js
+++ b/components/PushAnimation/index.js
@@ -1,13 +1,14 @@
 import { motion as m } from "framer-motion";
 import styles from "./styles.module.css";
 
-const PushAnimation = ({ children }) => {
+const PushAnimation = ({ children, isGameboard }) => {
   return (
     <m.div
       initial={{ x: "-100vw" }}
       animate={{ x: 0 }}
       transition={{ delay: 0.4, ease: "backOut", duration: 0.6 }}
       className={styles.push}
+      style={isGameboard && { height: "70%" }}
     >
       {children}
     </m.div>

--- a/components/PushAnimation/styles.module.css
+++ b/components/PushAnimation/styles.module.css
@@ -1,6 +1,5 @@
 .push {
   width: 80%;
-  height: 70%;
   display: flex;
   justify-content: center;
 }

--- a/components/Results/index.js
+++ b/components/Results/index.js
@@ -8,7 +8,7 @@ const Results = () => {
   const sortedPlayerValues = playerValues.sort((a, b) => b.score - a.score);
 
   return (
-    <PushAnimation>
+    <PushAnimation isGameboard={false}>
       <div className={styles.playerListBorder}>
         <ol className={styles.playerList}>
           {sortedPlayerValues.map((player, index) => (

--- a/components/Results/styles.module.css
+++ b/components/Results/styles.module.css
@@ -2,7 +2,6 @@
   border: solid 12px var(--yellow);
   border-radius: 8px;
   box-shadow: 1px 1px 2px black;
-  max-height: 276px;
 }
 
 .playerList {
@@ -47,4 +46,13 @@
 .playerName {
   color: #d04eff;
   font-size: 36px;
+}
+
+@media (max-width: 768px) {
+  .playerListBorder {
+    width: 100%;
+  }
+  .playerList {
+    width: auto;
+  }
 }

--- a/components/ResultsHeading/styles.module.css
+++ b/components/ResultsHeading/styles.module.css
@@ -5,3 +5,10 @@
   text-shadow: 0 1px 0 #3c391e, 0 2px 0 #3c391e, 0 3px 0 #3c391e,
     0 4px 0 #3c391e, 0 5px 0 #3c391e, 0 20px 30px rgba(0, 0, 0, 0.5);
 }
+
+@media (max-width: 768px) {
+  .heading {
+    font-size: 80px;
+    margin-top: 100px;
+  }
+}


### PR DESCRIPTION
This PR:
- adds breakpoints to the results pages 
- makes adjustment to reusable component PushAnimation to fix layout issues between the components that use it

Example picture:
<img width="579" alt="Screen Shot 2023-03-27 at 1 02 20 PM" src="https://user-images.githubusercontent.com/100656411/228053993-7c18a297-214d-4d82-9e95-b82c46402cf1.png">
